### PR TITLE
fix: Add feature flags for csr, ssr, and hydrate

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -13,3 +13,8 @@ strum_macros = "0.26.2"
 itertools = "0.12.1"
 wasm-bindgen = "=0.2.92"
 web-sys = { version = "0.3.65", features = ["CustomEventInit", "EventInit"] }
+
+[features]
+csr = ["leptos/csr"]
+ssr = ["leptos/ssr", "leptos-use/ssr"]
+hydrate = ["leptos/hydrate"]


### PR DESCRIPTION
components using leptos-use panic when leptos-use/ssr isn't defined in user's dependencies when in ssr mode

also stuck in leptos/ssr, although i don't think it would be a problem since people using ssr would need to define it in their own projects, it'd probably be better safe than sorry
