### PR TITLE
Fix slider crash on unmount with disposed signals.

### DIFF
--- a/crates/primitives/src/components/collection.rs
+++ b/crates/primitives/src/components/collection.rs
@@ -60,7 +60,7 @@ pub fn create_collection_item_ref<
     });
 
     on_cleanup(move || {
-      item_map.update(|item_map| {
+      item_map.try_update(|item_map| {
         item_map.remove(&id.clone());
       });
     });

--- a/crates/primitives/src/components/slider.rs
+++ b/crates/primitives/src/components/slider.rs
@@ -804,7 +804,7 @@ pub fn SliderThumb(
     });
 
     on_cleanup(move || {
-      context.thumbs.update_value(|thumbs| {
+      context.thumbs.try_update_value(|thumbs| {
         if let Some(position) = thumbs.iter().position(|thumb| {
           let thumb_el: &web_sys::Element = thumb;
           let node_el: &web_sys::Element = &node.clone();


### PR DESCRIPTION
Really cool library, see a lot of potential here.

I was trying to use the slider, but unmounting would crash my app with various undisposed signal panics. 

The changes in here prevent the crashes. 

There are still *a lot* of `outside a reactive tracking context` warnings on mount, and still `called Result::unwrap() on an Err value: OwnerDisposed(Owner(NodeId(1223v3)))` errors on unmount, but neither of these crash my app like before this PR. I'll open this as a separate issue.