### PR TITLE
fix: add as_child to all components + make existing as_child props reactive

### DIFF
--- a/crates/primitives/src/components/accordion.rs
+++ b/crates/primitives/src/components/accordion.rs
@@ -70,9 +70,11 @@ pub fn AccordionRoot(
   #[prop(optional, into)] direction: MaybeSignal<Direction>,
   #[prop(default=Orientation::Vertical.into(), into)] orientation: MaybeSignal<Orientation>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   provide_context(
     CollectionContextValue::<AccordionCollectionItem, AnyElement> {
@@ -89,8 +91,6 @@ pub fn AccordionRoot(
       collapsible,
     } => view! {
       <AccordionSingleImpl
-        attrs=attrs
-        node_ref=node_ref
         value=value
         default_value=default_value
         on_value_change=on_value_change.unwrap_or((|_|{}).into())
@@ -98,6 +98,9 @@ pub fn AccordionRoot(
         disabled=Signal::derive(move || disabled.get())
         direction=Signal::derive(move || direction.get())
         orientation=Signal::derive(move || orientation.get())
+        node_ref=node_ref
+        attrs=attrs
+        as_child=as_child
       >
         {children()}
       </AccordionSingleImpl>
@@ -108,14 +111,15 @@ pub fn AccordionRoot(
       on_value_change,
     } => view! {
       <AccordionMultipleImpl
-        attrs=attrs
-        node_ref=node_ref
         value=value
         default_value=default_value
         on_value_change=on_value_change.unwrap_or((|_|{}).into())
         disabled=Signal::derive(move || disabled.get())
         direction=Signal::derive(move || direction.get())
         orientation=Signal::derive(move || orientation.get())
+        node_ref=node_ref
+        attrs=attrs
+        as_child=as_child
       >
         {children()}
       </AccordionMultipleImpl>
@@ -135,9 +139,11 @@ fn AccordionSingleImpl(
   direction: Signal<Direction>,
   orientation: Signal<Orientation>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (value, set_value) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || value.get()),
@@ -173,6 +179,7 @@ fn AccordionSingleImpl(
       orientation=orientation
       node_ref=node_ref
       attrs=attrs
+      as_child=as_child
     >
       {children()}
     </Accordion>
@@ -190,9 +197,11 @@ fn AccordionMultipleImpl(
   direction: Signal<Direction>,
   orientation: Signal<Orientation>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (value, set_value) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || value.get()),
@@ -240,6 +249,7 @@ fn AccordionMultipleImpl(
       orientation=orientation
       node_ref=node_ref
       attrs=attrs
+      as_child=as_child
     >
       {children()}
     </Accordion>
@@ -263,9 +273,11 @@ fn Accordion(
   direction: Signal<Direction>,
   #[prop(default=(|_|{}).into(), into)] on_key_down: Callback<KeyboardEvent>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let get_items = use_collection_context::<AccordionCollectionItem, AnyElement>();
 
@@ -288,8 +300,8 @@ fn Accordion(
   view! {
     <Primitive
       element=html::div
-      attrs=merged_attrs
       node_ref=node_ref
+      attrs=merged_attrs
       on:keydown=move |ev: KeyboardEvent| {
         on_key_down.call(ev.clone());
 
@@ -389,6 +401,7 @@ fn Accordion(
           Some(())
         })();
       }
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -406,9 +419,12 @@ struct AccordionItemContextValue {
 pub fn AccordionItem(
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
   #[prop(into)] value: MaybeSignal<String>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let state_context = use_context::<AccordionStateContextValue>()
     .expect("AccordionItem must be in an Accordion component");
@@ -460,6 +476,7 @@ pub fn AccordionItem(
           value_context.on_item_close.call(open_value.get());
         }
       })
+      as_child=as_child
     >
       {children()}
     </CollapsibleRoot>
@@ -468,9 +485,11 @@ pub fn AccordionItem(
 
 #[component]
 pub fn AccordionHeader(
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let state_context = use_context::<AccordionStateContextValue>()
     .expect("AccordionHeader must be in an Accordion component");
@@ -504,8 +523,9 @@ pub fn AccordionHeader(
   view! {
     <Primitive
       element=html::h3
-      attrs=merged_attrs
       node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -514,9 +534,11 @@ pub fn AccordionHeader(
 
 #[component]
 pub fn AccordionTrigger(
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let state_context = use_context::<AccordionStateContextValue>()
     .expect("AccordionTrigger must be in an Accordion component");
@@ -548,6 +570,7 @@ pub fn AccordionTrigger(
     <CollapsibleTrigger
       node_ref=node_ref
       attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </CollapsibleTrigger>
@@ -556,9 +579,11 @@ pub fn AccordionTrigger(
 
 #[component]
 pub fn AccordionContent(
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let state_context = use_context::<AccordionStateContextValue>()
     .expect("AccordionTrigger must be in an Accordion component");
@@ -599,6 +624,7 @@ pub fn AccordionContent(
     <CollapsibleContent
       node_ref=node_ref
       attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </CollapsibleContent>

--- a/crates/primitives/src/components/accordion.rs
+++ b/crates/primitives/src/components/accordion.rs
@@ -300,8 +300,6 @@ fn Accordion(
   view! {
     <Primitive
       element=html::div
-      node_ref=node_ref
-      attrs=merged_attrs
       on:keydown=move |ev: KeyboardEvent| {
         on_key_down.call(ev.clone());
 
@@ -401,6 +399,8 @@ fn Accordion(
           Some(())
         })();
       }
+      node_ref=node_ref
+      attrs=merged_attrs
       as_child=as_child
     >
       {children()}
@@ -465,10 +465,8 @@ pub fn AccordionItem(
   let open_value = value.clone();
   view! {
     <CollapsibleRoot
-      attrs=merged_attrs
       open=is_open
       disabled=is_disabled
-      node_ref=node_ref
       on_open_change=Callback::new(move |open| {
         if open {
           value_context.on_item_open.call(open_value.get());
@@ -476,6 +474,8 @@ pub fn AccordionItem(
           value_context.on_item_close.call(open_value.get());
         }
       })
+      node_ref=node_ref
+      attrs=merged_attrs
       as_child=as_child
     >
       {children()}

--- a/crates/primitives/src/components/accordion.rs
+++ b/crates/primitives/src/components/accordion.rs
@@ -72,7 +72,7 @@ pub fn AccordionRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -141,7 +141,7 @@ fn AccordionSingleImpl(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -199,7 +199,7 @@ fn AccordionMultipleImpl(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -275,7 +275,7 @@ fn Accordion(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -422,7 +422,7 @@ pub fn AccordionItem(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -487,7 +487,7 @@ pub fn AccordionItem(
 pub fn AccordionHeader(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -536,7 +536,7 @@ pub fn AccordionHeader(
 pub fn AccordionTrigger(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {

--- a/crates/primitives/src/components/aspect_ratio.rs
+++ b/crates/primitives/src/components/aspect_ratio.rs
@@ -8,7 +8,7 @@ pub fn AspectRatioRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {

--- a/crates/primitives/src/components/aspect_ratio.rs
+++ b/crates/primitives/src/components/aspect_ratio.rs
@@ -5,9 +5,12 @@ use crate::{components::primitive::Primitive, Attributes};
 #[component]
 pub fn AspectRatioRoot(
   #[prop(default=1.0f64.into(), into)] ratio: MaybeSignal<f64>,
-  children: Children,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
+  children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let mut merged_attrs = attrs.clone();
 
@@ -25,6 +28,7 @@ pub fn AspectRatioRoot(
         element=html::div
         node_ref=node_ref
         attrs=merged_attrs
+        as_child=as_child
       >
         {children()}
       </Primitive>

--- a/crates/primitives/src/components/avatar.rs
+++ b/crates/primitives/src/components/avatar.rs
@@ -1,4 +1,4 @@
-use html::{Img, Span};
+use html::{AnyElement, Img, Span};
 use leptos::*;
 use leptos_use::{use_timeout_fn, UseTimeoutFnReturn};
 use wasm_bindgen::{closure::Closure, JsCast};
@@ -13,9 +13,9 @@ pub struct AvatarContextValue {
 
 #[component]
 pub fn AvatarRoot(
-  #[prop(optional)] node_ref: NodeRef<Span>,
+  #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -44,9 +44,9 @@ pub fn AvatarRoot(
 pub fn AvatarImage(
   #[prop(default=(|_|{}).into(), into)] on_loading_status_change: Callback<ImageLoadingStatus>,
 
-  #[prop(optional)] node_ref: NodeRef<Img>,
+  #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional)] children: Option<Children>,
+  #[prop(optional)] children: Option<ChildrenFn>,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -81,9 +81,9 @@ pub fn AvatarImage(
         element=html::img
         node_ref=node_ref
         attrs=attrs.clone()
-        as_child=as_child.clone()
+        as_child=as_child
       >
-        {children.with_value(|children| children.map(|children| children()))}
+        {children.with_value(|children| children.as_ref().map(|children| children()))}
       </Primitive>
     </Show>
   }
@@ -93,7 +93,7 @@ pub fn AvatarImage(
 pub fn AvatarFallback(
   #[prop(optional, into)] delay_ms: MaybeSignal<f64>,
 
-  #[prop(optional)] node_ref: NodeRef<Span>,
+  #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
 
@@ -114,14 +114,17 @@ pub fn AvatarFallback(
     start(());
   });
 
+  let children = StoredValue::new(children);
+
   view! {
     <Show when=move || can_render.get() && context.image_loading_status.get() != ImageLoadingStatus::Loaded>
       <Primitive
         element=html::span
         node_ref=node_ref
-        as_child=as_child.clone()
+        as_child=as_child
+        attrs=attrs.clone()
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Primitive>
     </Show>
   }

--- a/crates/primitives/src/components/checkbox.rs
+++ b/crates/primitives/src/components/checkbox.rs
@@ -44,7 +44,7 @@ pub fn CheckboxRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -252,7 +252,7 @@ pub fn CheckboxIndicator(
         element=html::span
         node_ref=node_ref
         attrs=merged_attrs.clone()
-        as_child=as_child.clone()
+        as_child=as_child
       >
         {children.with_value(|children| children())}
       </Primitive>

--- a/crates/primitives/src/components/checkbox.rs
+++ b/crates/primitives/src/components/checkbox.rs
@@ -103,51 +103,6 @@ pub fn CheckboxRoot(
     disabled: Signal::derive(move || disabled.get()),
   });
 
-  let mut merged_attrs = vec![
-    ("type", "button".into_attribute()),
-    ("role", "checkbox".into_attribute()),
-    (
-      "aria-checked",
-      Signal::derive(move || {
-        checked.get().map(|checked| match checked {
-          CheckedState::Checked(checked) => checked.into_attribute(),
-          CheckedState::Indeterminate => "mixed".into_attribute(),
-        })
-      })
-      .into_attribute(),
-    ),
-    (
-      "aria-required",
-      Signal::derive(move || required.get()).into_attribute(),
-    ),
-    (
-      "data-state",
-      Signal::derive(move || {
-        checked.get().map(|checked| match checked {
-          CheckedState::Checked(checked) => {
-            if checked {
-              "checked"
-            } else {
-              "unchecked"
-            }
-          }
-          CheckedState::Indeterminate => "indeterminate",
-        })
-      })
-      .into_attribute(),
-    ),
-    (
-      "data-disabled",
-      Signal::derive(move || disabled.get()).into_attribute(),
-    ),
-    (
-      "disabled",
-      Signal::derive(move || disabled.get()).into_attribute(),
-    ),
-  ];
-
-  merged_attrs.extend(attrs);
-
   let bubble_ref = NodeRef::<Input>::new();
 
   Effect::new(move |_| {
@@ -160,9 +115,32 @@ pub fn CheckboxRoot(
 
   view! {
     <Primitive
+      {..attrs}
       element=html::button
       node_ref=node_ref
-      attrs=merged_attrs
+      attr:type="button"
+      attr:role="checkbox"
+      attr:aria-checked=move || {
+        checked.get().map(|checked| match checked {
+          CheckedState::Checked(checked) => checked.into_attribute(),
+          CheckedState::Indeterminate => "mixed".into_attribute(),
+        })
+      }
+      attr:aria-required=required
+      attr:data-state=move || {
+        checked.get().map(|checked| match checked {
+          CheckedState::Checked(checked) => {
+            if checked {
+              "checked"
+            } else {
+              "unchecked"
+            }
+          }
+          CheckedState::Indeterminate => "indeterminate",
+        })
+      }
+      attr:data-disabled=disabled
+      attr:disabled=disabled
       as_child=as_child
       on:keydown=move |ev: KeyboardEvent| {
         on_key_down.call(ev.clone());
@@ -215,36 +193,24 @@ pub fn CheckboxIndicator(
 
   let presence = create_presence(is_present, node_ref);
 
-  let mut merged_attrs = vec![
-    (
-      "data-state",
-      Signal::derive(move || match state.get() {
-        CheckedState::Checked(checked) => {
-          if checked {
-            "checked"
-          } else {
-            "unchecked"
-          }
-        }
-        CheckedState::Indeterminate => "indeterminate",
-      })
-      .into_attribute(),
-    ),
-    (
-      "data-disabled",
-      Signal::derive(move || disabled.get()).into_attribute(),
-    ),
-  ];
-
-  merged_attrs.extend(attrs.clone());
-
   let children = StoredValue::new(children);
 
   view! {
     <Show when=move || presence.get()>
       <Primitive
+          {..attrs.clone()}
+          attr:data-state=move || match state.get() {
+            CheckedState::Checked(checked) => {
+              if checked {
+                "checked"
+              } else {
+                "unchecked"
+              }
+            }
+            CheckedState::Indeterminate => "indeterminate",
+          }
+          attr:disabled=disabled.clone()
           element=html::span
-          attrs=merged_attrs.clone()
           node_ref=node_ref
       >
           {children.with_value(|children| children())}

--- a/crates/primitives/src/components/checkbox.rs
+++ b/crates/primitives/src/components/checkbox.rs
@@ -46,7 +46,7 @@ pub fn CheckboxRoot(
   #[prop(attrs)] attrs: Attributes,
   children: Children,
 
-  #[prop(optional)] as_child: Option<bool>,
+  #[prop(optional)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let has_consumer_stropped_propagation = StoredValue::new(false);
 

--- a/crates/primitives/src/components/collapsible.rs
+++ b/crates/primitives/src/components/collapsible.rs
@@ -26,12 +26,15 @@ pub fn CollapsibleRoot(
   #[prop(optional, into)] open: MaybeSignal<bool>,
   #[prop(optional, into)] default_open: MaybeSignal<bool>,
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
+
   #[prop(default=(|_|{}).into(), into)] on_open_change: Callback<bool>,
   #[prop(default=(|_|{}).into(), into)] on_click: Callback<MouseEvent>,
-  #[prop(optional, into)] as_child: Option<bool>,
+
   #[prop(optional, into)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (open, set_open) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || Some(open.get())),
@@ -71,8 +74,8 @@ pub fn CollapsibleRoot(
     <Primitive
       element=html::div
       node_ref=node_ref
-      as_child=as_child
       attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -81,11 +84,13 @@ pub fn CollapsibleRoot(
 
 #[component]
 pub fn CollapsibleTrigger(
-  #[prop(optional)] as_child: Option<bool>,
-  #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(default=(|_|{}).into(), into)] on_click: Callback<MouseEvent>,
+
+  #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let CollapsibleContextValue {
     content_id,
@@ -111,13 +116,13 @@ pub fn CollapsibleTrigger(
   view! {
     <Primitive
       element=html::button
-      attrs=merged_attrs
-      node_ref=node_ref
-      as_child=as_child
       on:click=move |ev: MouseEvent| {
         on_click.call(ev);
         on_open_toggle.call(());
       }
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -127,10 +132,12 @@ pub fn CollapsibleTrigger(
 #[component]
 pub fn CollapsibleContent(
   #[prop(optional, into)] force_mount: MaybeSignal<bool>,
-  #[prop(optional)] as_child: Option<bool>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let CollapsibleContextValue { open, .. } = use_context::<CollapsibleContextValue>()
     .expect("CollapsibleContent must be used in a CollapsibleRoot component");
@@ -142,25 +149,27 @@ pub fn CollapsibleContent(
 
   view! {
     <Show when=move || presence.get()>
-        <CollapsibleContentImpl
-            as_child=as_child
-            attrs=attrs.clone()
-            node_ref=node_ref
-            is_present=presence
-        >
-            {children.with_value(|children| children())}
-        </CollapsibleContentImpl>
+      <CollapsibleContentImpl
+        is_present=presence
+        node_ref=node_ref
+        attrs=attrs.clone()
+        as_child=as_child.clone()
+      >
+        {children.with_value(|children| children())}
+      </CollapsibleContentImpl>
     </Show>
   }
 }
 
 #[component]
 fn CollapsibleContentImpl(
-  as_child: Option<bool>,
-  #[prop(attrs)] attrs: Attributes,
-  node_ref: NodeRef<AnyElement>,
   is_present: Signal<bool>,
+
+  node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let CollapsibleContextValue {
     content_id,
@@ -292,9 +301,9 @@ fn CollapsibleContentImpl(
   view! {
     <Primitive
       element=html::div
+      node_ref=node_ref
       attrs=merged_attrs
       as_child=as_child
-      node_ref=node_ref
     >
       <Show when=move || is_open.get()>
         {children()}

--- a/crates/primitives/src/components/collapsible.rs
+++ b/crates/primitives/src/components/collapsible.rs
@@ -32,7 +32,7 @@ pub fn CollapsibleRoot(
 
   #[prop(optional, into)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -88,7 +88,7 @@ pub fn CollapsibleTrigger(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -153,7 +153,7 @@ pub fn CollapsibleContent(
         is_present=presence
         node_ref=node_ref
         attrs=attrs.clone()
-        as_child=as_child.clone()
+        as_child=as_child
       >
         {children.with_value(|children| children())}
       </CollapsibleContentImpl>
@@ -298,6 +298,8 @@ fn CollapsibleContentImpl(
 
   merged_attrs.extend(attrs);
 
+  let children = StoredValue::new(children);
+
   view! {
     <Primitive
       element=html::div
@@ -306,7 +308,7 @@ fn CollapsibleContentImpl(
       as_child=as_child
     >
       <Show when=move || is_open.get()>
-        {children()}
+        {children.with_value(|children| children())}
       </Show>
     </Primitive>
   }

--- a/crates/primitives/src/components/label.rs
+++ b/crates/primitives/src/components/label.rs
@@ -11,7 +11,7 @@ pub fn LabelRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {

--- a/crates/primitives/src/components/label.rs
+++ b/crates/primitives/src/components/label.rs
@@ -6,10 +6,14 @@ use crate::{components::primitive::Primitive, Attributes};
 #[component]
 pub fn LabelRoot(
   #[prop(optional, into)] for_html: MaybeProp<String>,
+
   #[prop(default=(|_|{}).into(), into)] on_mouse_down: Callback<MouseEvent>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let mut merged_attrs = attrs.clone();
   merged_attrs.push(("for", for_html.into_attribute()));
@@ -17,15 +21,16 @@ pub fn LabelRoot(
   view! {
     <Primitive
       element=html::label
-      attrs=merged_attrs
-      node_ref=node_ref
       on:mousedown=move |ev: MouseEvent| {
-          on_mouse_down.call(ev.clone());
+        on_mouse_down.call(ev.clone());
 
         if ev.default_prevented() && ev.detail() > 1 {
           ev.prevent_default();
         }
       }
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>

--- a/crates/primitives/src/components/primitive.rs
+++ b/crates/primitives/src/components/primitive.rs
@@ -11,23 +11,31 @@ pub fn Primitive<El: ElementDescriptor + 'static>(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
+  let children = StoredValue::new(children);
+  let attrs = StoredValue::new(attrs);
+
   view! {
-    {move || {
-      if as_child.get().unwrap_or_default() {
-        map_items_to_children(children().as_children(), attrs, node_ref)
-      } else {
-        element()
-          .attrs(attrs)
-          .child(children().into_view())
-          .into_any()
-          .node_ref(node_ref)
-          .into_view()
+    <Show
+      when=move || as_child.get().unwrap_or_default()
+      fallback=move || element()
+        .attrs(attrs.get_value())
+        .child(children.with_value(|children| children()).into_view())
+        .into_any()
+        .node_ref(node_ref)
+        .into_view()
+    >
+      {
+        map_items_to_children(
+          children.with_value(|children| children()).as_children(),
+          attrs.get_value(),
+          node_ref,
+        )
       }
-    }}
+    </Show>
   }
 }
 

--- a/crates/primitives/src/components/primitive.rs
+++ b/crates/primitives/src/components/primitive.rs
@@ -8,21 +8,26 @@ use crate::Attributes;
 #[component]
 pub fn Primitive<El: ElementDescriptor + 'static>(
   element: fn() -> HtmlElement<El>,
+
+  #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
 
-  #[prop(attrs)] attrs: Attributes,
-  #[prop(optional_no_strip)] as_child: Option<bool>,
-  #[prop(optional_no_strip)] node_ref: NodeRef<AnyElement>,
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
-  if as_child.unwrap_or(false) {
-    map_items_to_children(children().as_children(), attrs, node_ref)
-  } else {
-    element()
-      .attrs(attrs)
-      .child(children().into_view())
-      .into_any()
-      .node_ref(node_ref)
-      .into_view()
+  view! {
+    {move || {
+      if as_child.get().unwrap_or_default() {
+        map_items_to_children(children().as_children(), attrs, node_ref)
+      } else {
+        element()
+          .attrs(attrs)
+          .child(children().into_view())
+          .into_any()
+          .node_ref(node_ref)
+          .into_view()
+      }
+    }}
   }
 }
 

--- a/crates/primitives/src/components/progress.rs
+++ b/crates/primitives/src/components/progress.rs
@@ -19,7 +19,7 @@ pub fn ProgressRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -100,7 +100,7 @@ pub fn ProgressRoot(
 pub fn ProgressIndicator(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional)] children: Option<Children>,
+  #[prop(optional)] children: Option<ChildrenFn>,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -130,6 +130,8 @@ pub fn ProgressIndicator(
     ("data-max", max.into_attribute()),
   ]);
 
+  let children = StoredValue::new(children);
+
   view! {
     <Primitive
       element=html::div
@@ -137,7 +139,7 @@ pub fn ProgressIndicator(
       attrs=merged_attrs
       as_child=as_child
     >
-      {children.map(|children| children())}
+      {children.with_value(|children| children.as_ref().map(|children| children()))}
     </Primitive>
   }
 }

--- a/crates/primitives/src/components/progress.rs
+++ b/crates/primitives/src/components/progress.rs
@@ -14,10 +14,14 @@ struct ProgressContextValue {
 pub fn ProgressRoot(
   #[prop(optional, into)] value: MaybeProp<f64>,
   #[prop(default=100.0f64.into(), into)] max: MaybeSignal<f64>,
+
   #[prop(optional)] get_value_label: Option<Callback<(f64, f64), String>>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let max = Signal::derive(move || {
     let max = max.get();
@@ -85,6 +89,7 @@ pub fn ProgressRoot(
       element=html::div
       node_ref=node_ref
       attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -95,6 +100,9 @@ pub fn ProgressRoot(
 pub fn ProgressIndicator(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
+  #[prop(optional)] children: Option<Children>,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let ProgressContextValue { max, value } =
     use_context().expect("ProgressIndicator needs to be in a Progress component");
@@ -127,8 +135,9 @@ pub fn ProgressIndicator(
       element=html::div
       node_ref=node_ref
       attrs=merged_attrs
+      as_child=as_child
     >
-      {().into_view()}
+      {children.map(|children| children())}
     </Primitive>
   }
 }

--- a/crates/primitives/src/components/radio.rs
+++ b/crates/primitives/src/components/radio.rs
@@ -34,7 +34,7 @@ pub fn Radio(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -162,7 +162,7 @@ pub fn RadioIndicator(
         element=html::span
         node_ref=node_ref
         attrs=merged_attrs.clone()
-        as_child=as_child.clone()
+        as_child=as_child
       >
         {children.with_value(|children| children())}
       </Primitive>

--- a/crates/primitives/src/components/radio.rs
+++ b/crates/primitives/src/components/radio.rs
@@ -46,34 +46,6 @@ pub fn Radio(
     });
   });
 
-  let mut merged_attrs = vec![
-    ("type", "button".into_attribute()),
-    ("role", "radio".into_attribute()),
-    (
-      "aria-checked",
-      (move || checked.get().to_string()).into_attribute(),
-    ),
-    (
-      "data-state",
-      (move || {
-        if checked.get() {
-          "checked"
-        } else {
-          "unchecked"
-        }
-      })
-      .into_attribute(),
-    ),
-    ("data-disabled", disabled.into_attribute()),
-    (
-      "disabled",
-      (move || disabled.get().then_some("")).into_attribute(),
-    ),
-    ("value", value.clone().into_attribute()),
-  ];
-
-  merged_attrs.extend(attrs);
-
   provide_context(RadioContextValue {
     checked: Signal::derive(move || checked.get()),
     disabled: Signal::derive(move || disabled.get()),
@@ -81,6 +53,20 @@ pub fn Radio(
 
   view! {
     <Primitive
+      {..attrs}
+      attr:type="button"
+      attr:role="radio"
+      attr:aria-checked=move || checked.get().to_string()
+      attr:data-state=move || {
+        if checked.get() {
+          "checked"
+        } else {
+          "unchecked"
+        }
+      }
+      attr:data-disabled=disabled
+      attr:disabled=move || disabled.get().then_some("")
+      attr:value=value
       element=html::button
       attrs=merged_attrs
       node_ref=node_ref
@@ -128,30 +114,22 @@ pub fn RadioIndicator(
     use_context().expect("RadioIndicator must be used in a Radio component");
 
   let is_present = Signal::derive(move || force_mount.get() || checked.get());
-
   let presence = create_presence(is_present, node_ref);
-  let mut merged_attrs = attrs.clone();
-
-  merged_attrs.extend([
-    (
-      "data-state",
-      (move || {
-        if checked.get() {
-          "checked"
-        } else {
-          "unchecked"
-        }
-      })
-      .into_attribute(),
-    ),
-    ("data-disabled", disabled.into_attribute()),
-  ]);
 
   let children = StoredValue::new(children);
 
   view! {
     <Show when=move || presence.get()>
         <Primitive
+            {..attrs.clone()}
+            attr:data-state=move || {
+              if checked.get() {
+                "checked"
+              } else {
+                "unchecked"
+              }
+            }
+            attr:data-disabled=disabled.clone()
             element=html::span
             node_ref=node_ref
             attrs=merged_attrs.clone()

--- a/crates/primitives/src/components/radio.rs
+++ b/crates/primitives/src/components/radio.rs
@@ -31,9 +31,12 @@ pub fn Radio(
 
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
   #[prop(optional, into)] name: MaybeProp<String>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (is_form_control, set_is_form_control) = create_signal(true);
   let has_consumer_stopped_propagation = StoredValue::new(false);
@@ -46,6 +49,34 @@ pub fn Radio(
     });
   });
 
+  let mut merged_attrs = vec![
+    ("type", "button".into_attribute()),
+    ("role", "radio".into_attribute()),
+    (
+      "aria-checked",
+      (move || checked.get().to_string()).into_attribute(),
+    ),
+    (
+      "data-state",
+      (move || {
+        if checked.get() {
+          "checked"
+        } else {
+          "unchecked"
+        }
+      })
+      .into_attribute(),
+    ),
+    ("data-disabled", disabled.into_attribute()),
+    (
+      "disabled",
+      (move || disabled.get().then_some("")).into_attribute(),
+    ),
+    ("value", value.clone().into_attribute()),
+  ];
+
+  merged_attrs.extend(attrs);
+
   provide_context(RadioContextValue {
     checked: Signal::derive(move || checked.get()),
     disabled: Signal::derive(move || disabled.get()),
@@ -53,28 +84,12 @@ pub fn Radio(
 
   view! {
     <Primitive
-      {..attrs}
-      attr:type="button"
-      attr:role="radio"
-      attr:aria-checked=move || checked.get().to_string()
-      attr:data-state=move || {
-        if checked.get() {
-          "checked"
-        } else {
-          "unchecked"
-        }
-      }
-      attr:data-disabled=disabled
-      attr:disabled=move || disabled.get().then_some("")
-      attr:value=value
       element=html::button
-      attrs=merged_attrs
-      node_ref=node_ref
       on:click=move |ev: MouseEvent| {
-          on_click.call(ev.clone());
+        on_click.call(ev.clone());
 
         if !checked.get() {
-            on_check.call(())
+          on_check.call(())
         }
 
         if is_form_control.get() {
@@ -85,57 +100,72 @@ pub fn Radio(
           }
         }
       }
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
-
-        <Show when=move || is_form_control.get()>
-            <BubbleInput
-                checked=Signal::derive(move || checked.get())
-                bubbles=Signal::derive(move || !has_consumer_stopped_propagation.get_value())
-                name=name.clone()
-                value=value.clone()
-                required=Signal::derive(move || required.get())
-                disabled=Signal::derive(move || disabled.get())
-                control=node_ref
-            />
-        </Show>
     </Primitive>
+
+    <Show when=move || is_form_control.get()>
+      <BubbleInput
+        checked=Signal::derive(move || checked.get())
+        bubbles=Signal::derive(move || !has_consumer_stopped_propagation.get_value())
+        name=name.clone()
+        value=value.clone()
+        required=Signal::derive(move || required.get())
+        disabled=Signal::derive(move || disabled.get())
+        control=node_ref
+      />
+    </Show>
   }
 }
 
 #[component]
 pub fn RadioIndicator(
   #[prop(optional, into)] force_mount: MaybeSignal<bool>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let RadioContextValue { checked, disabled } =
     use_context().expect("RadioIndicator must be used in a Radio component");
 
   let is_present = Signal::derive(move || force_mount.get() || checked.get());
+
   let presence = create_presence(is_present, node_ref);
+  let mut merged_attrs = attrs.clone();
+
+  merged_attrs.extend([
+    (
+      "data-state",
+      (move || {
+        if checked.get() {
+          "checked"
+        } else {
+          "unchecked"
+        }
+      })
+      .into_attribute(),
+    ),
+    ("data-disabled", disabled.into_attribute()),
+  ]);
 
   let children = StoredValue::new(children);
 
   view! {
     <Show when=move || presence.get()>
-        <Primitive
-            {..attrs.clone()}
-            attr:data-state=move || {
-              if checked.get() {
-                "checked"
-              } else {
-                "unchecked"
-              }
-            }
-            attr:data-disabled=disabled.clone()
-            element=html::span
-            node_ref=node_ref
-            attrs=merged_attrs.clone()
-        >
-            {children.with_value(|children| children())}
-        </Primitive>
+      <Primitive
+        element=html::span
+        node_ref=node_ref
+        attrs=merged_attrs.clone()
+        as_child=as_child.clone()
+      >
+        {children.with_value(|children| children())}
+      </Primitive>
     </Show>
   }
 }

--- a/crates/primitives/src/components/radio_group.rs
+++ b/crates/primitives/src/components/radio_group.rs
@@ -39,10 +39,14 @@ pub fn RadioGroupRoot(
   #[prop(optional, into)] default_value: MaybeProp<String>,
   #[prop(optional, into)] orientation: MaybeSignal<Orientation>,
   #[prop(optional, into)] direction: MaybeSignal<Direction>,
+
   #[prop(default=(|_|{}).into(), into)] on_value_change: Callback<String>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (value, set_value) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || value.get()),
@@ -87,6 +91,7 @@ pub fn RadioGroupRoot(
         element=html::div
         attrs=merged_attrs
         node_ref=node_ref
+        as_child=as_child
       >
         {children()}
       </Primitive>
@@ -96,13 +101,17 @@ pub fn RadioGroupRoot(
 
 #[component]
 pub fn RadioGroupItem(
+  #[prop(optional, into)] disabled: MaybeSignal<bool>,
   #[prop(into)] value: MaybeSignal<String>,
+
   #[prop(default=(|_|{}).into(), into)] on_focus: Callback<FocusEvent>,
   #[prop(default=(|_|{}).into(), into)] on_key_down: Callback<KeyboardEvent>,
-  #[prop(optional, into)] disabled: MaybeSignal<bool>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let RadioGroupContextValue {
     disabled,
@@ -142,8 +151,6 @@ pub fn RadioGroupItem(
         required=required
         checked=is_checked
         name=name
-        node_ref=node_ref
-        attrs=attrs
         on_check=Callback::new(move |_| on_value_change.call(on_check_value.get()))
         on:keydown=move |ev: KeyboardEvent| {
           on_key_down.call(ev.clone());
@@ -167,6 +174,9 @@ pub fn RadioGroupItem(
             node_el.click();
           }
         }
+        node_ref=node_ref
+        attrs=attrs
+        as_child=as_child
       >
         {children()}
       </Radio>
@@ -178,14 +188,17 @@ pub fn RadioGroupItem(
 pub fn RadioGroupIndicator(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  // children: ChildrenFn,
+  #[prop(optional)] children: Option<ChildrenFn>,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   view! {
     <RadioIndicator
       attrs=attrs
       node_ref=node_ref
+      as_child=as_child
     >
-      {().into_view()}
+      {children.map(|children| children())}
     </RadioIndicator>
   }
 }

--- a/crates/primitives/src/components/radio_group.rs
+++ b/crates/primitives/src/components/radio_group.rs
@@ -44,7 +44,7 @@ pub fn RadioGroupRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -80,6 +80,8 @@ pub fn RadioGroupRoot(
 
   merged_attrs.extend(attrs);
 
+  let children = StoredValue::new(children);
+
   view! {
     <RovingFocusGroup
       as_child=true
@@ -90,10 +92,10 @@ pub fn RadioGroupRoot(
       <Primitive
         element=html::div
         node_ref=node_ref
-        attrs=merged_attrs
+        attrs=merged_attrs.clone()
         as_child=as_child
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Primitive>
     </RovingFocusGroup>
   }
@@ -109,7 +111,7 @@ pub fn RadioGroupItem(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -137,7 +139,8 @@ pub fn RadioGroupItem(
   //   is_arrow_key_pressed.set_value(false);
   // });
 
-  let on_check_value = value.clone();
+  let children = StoredValue::new(children);
+  let value = StoredValue::new(value);
 
   view! {
     <RovingFocusGroupItem
@@ -146,12 +149,12 @@ pub fn RadioGroupItem(
       active=is_checked
     >
       <Radio
-        value=value
+        value=value.get_value()
         disabled=is_disabled
         required=required
         checked=is_checked
-        name=name
-        on_check=Callback::new(move |_| on_value_change.call(on_check_value.get()))
+        name=name.clone()
+        on_check=Callback::new(move |_| on_value_change.call(value.get_value().get()))
         on:keydown=move |ev: KeyboardEvent| {
           on_key_down.call(ev.clone());
 
@@ -175,10 +178,10 @@ pub fn RadioGroupItem(
           }
         }
         node_ref=node_ref
-        attrs=attrs
+        attrs=attrs.clone()
         as_child=as_child
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Radio>
     </RovingFocusGroupItem>
   }
@@ -192,13 +195,15 @@ pub fn RadioGroupIndicator(
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
+  let children = StoredValue::new(children);
+
   view! {
     <RadioIndicator
       attrs=attrs
       node_ref=node_ref
       as_child=as_child
     >
-      {children.map(|children| children())}
+      {children.with_value(|children| children.as_ref().map(|children| children()))}
     </RadioIndicator>
   }
 }

--- a/crates/primitives/src/components/radio_group.rs
+++ b/crates/primitives/src/components/radio_group.rs
@@ -89,8 +89,8 @@ pub fn RadioGroupRoot(
     >
       <Primitive
         element=html::div
-        attrs=merged_attrs
         node_ref=node_ref
+        attrs=merged_attrs
         as_child=as_child
       >
         {children()}

--- a/crates/primitives/src/components/roving_focus.rs
+++ b/crates/primitives/src/components/roving_focus.rs
@@ -72,20 +72,23 @@ impl EventDescriptor for OnEntryFocus {
 
 #[component]
 pub(crate) fn RovingFocusGroup(
-  #[prop(optional)] as_child: Option<bool>,
   #[prop(optional, into)] orientation: MaybeProp<Orientation>,
   #[prop(optional, into)] direction: MaybeProp<Direction>,
   #[prop(optional, into)] should_loop: MaybeSignal<bool>,
   #[prop(optional, into)] current_tab_stop_id: MaybeProp<String>,
   #[prop(optional, into)] default_current_tab_stop_id: MaybeProp<String>,
+  #[prop(optional, into)] prevent_scroll_on_entry_focus: MaybeSignal<bool>,
+
   #[prop(default=(|_|{}).into(), into)] on_current_tab_stop_id_change: Callback<Option<String>>,
   #[prop(default=(|_|{}).into(), into)] on_entry_focus: Callback<Event>,
   #[prop(default=(|_|{}).into(), into)] on_mouse_down: Callback<MouseEvent>,
   #[prop(default=(|_|{}).into(), into)] on_focus: Callback<FocusEvent>,
   #[prop(default=(|_|{}).into(), into)] on_blur: Callback<FocusEvent>,
-  #[prop(optional, into)] prevent_scroll_on_entry_focus: MaybeSignal<bool>,
+
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let collection_ref = NodeRef::<html::AnyElement>::new();
 
@@ -158,9 +161,6 @@ pub(crate) fn RovingFocusGroup(
 
   view! {
     <Primitive element=html::div
-      as_child=as_child
-      attrs=merged_attrs
-      node_ref=collection_ref
       on:mousedown=move |ev: MouseEvent| {
           on_mouse_down.call(ev);
         is_click_focus.set_value(true);
@@ -207,6 +207,9 @@ pub(crate) fn RovingFocusGroup(
           on_blur.call(ev);
         set_is_tabbing_back_out.set(false);
       }
+      node_ref=collection_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -215,16 +218,19 @@ pub(crate) fn RovingFocusGroup(
 
 #[component]
 pub(crate) fn RovingFocusGroupItem(
-  #[prop(optional)] as_child: Option<bool>,
   #[prop(optional, into)] tab_stop_id: MaybeProp<String>,
   #[prop(optional, into)] focusable: MaybeSignal<bool>,
   #[prop(optional, into)] active: MaybeSignal<bool>,
+
   #[prop(default=(|_|{}).into(), into)] on_mouse_down: Callback<MouseEvent>,
   #[prop(default=(|_|{}).into(), into)] on_focus: Callback<FocusEvent>,
   #[prop(default=(|_|{}).into(), into)] on_key_down: Callback<KeyboardEvent>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let RovingContextValue {
     orientation,
@@ -278,9 +284,6 @@ pub(crate) fn RovingFocusGroupItem(
 
   view! {
     <Primitive element=html::span
-      as_child=as_child
-      attrs=merged_attrs
-      node_ref=node_ref
       on:mousedown=move |ev: MouseEvent| {
           on_mouse_down.call(ev.clone());
 
@@ -363,6 +366,9 @@ pub(crate) fn RovingFocusGroupItem(
           focus_first(candidate_nodes, false);
         }
       }
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>

--- a/crates/primitives/src/components/roving_focus.rs
+++ b/crates/primitives/src/components/roving_focus.rs
@@ -86,7 +86,7 @@ pub(crate) fn RovingFocusGroup(
   #[prop(default=(|_|{}).into(), into)] on_blur: Callback<FocusEvent>,
 
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -228,7 +228,7 @@ pub(crate) fn RovingFocusGroupItem(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {

--- a/crates/primitives/src/components/scroll_area.rs
+++ b/crates/primitives/src/components/scroll_area.rs
@@ -75,7 +75,7 @@ pub fn ScrollAreaRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -156,7 +156,7 @@ pub fn ScrollAreaViewport(
 
   //#[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -401,7 +401,7 @@ fn ScrollAreaScrollbarHover(
         orientation=orientation
         node_ref=node_ref
         attrs=merged_attrs.clone()
-        as_child=as_child.clone()
+        as_child=as_child
       >
         {children.with_value(|children| children())}
       </ScrollAreaScrollbarAuto>
@@ -528,7 +528,7 @@ fn ScrollAreaScrollbarAuto(
   #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
 
-  #[prop(optional, into)] as_child: MaybeSignal<bool>,
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarAuto must be used in a ScrollAreaRoot component");
@@ -580,7 +580,7 @@ fn ScrollAreaScrollbarAuto(
         orientation=orientation
         node_ref=node_ref
         attrs=merged_attrs.clone()
-        as_child=as_child.clone()
+        as_child=as_child
       >
         {children.with_value(|children| children())}
       </ScrollAreaScrollbarVisible>
@@ -1186,9 +1186,9 @@ pub fn ScrollAreaThumb(
       <ScrollAreaThumbImpl
         node_ref=node_ref
         attrs=attrs.clone()
-        as_child=as_child.clone()
+        as_child=as_child
       >
-        {children.with_value(|children| children.map(|children| children()))}
+        {children.with_value(|children| children.as_ref().map(|children| children()))}
       </ScrollAreaThumbImpl>
     </Show>
   }
@@ -1278,6 +1278,8 @@ fn ScrollAreaThumbImpl(
     scrollbar_context.on_thumb_change.call(node);
   });
 
+  let children = StoredValue::new(children);
+
   view! {
     <Primitive
       element=html::div
@@ -1285,7 +1287,7 @@ fn ScrollAreaThumbImpl(
       node_ref=node_ref
       attrs=attrs
     >
-      {children.map(|children| children())}
+      {children.with_value(|children| children.as_ref().map(|children| children()))}
     </Primitive>
   }
 }
@@ -1359,8 +1361,9 @@ pub fn ScrollAreaCorner(
         attrs=attrs.get_value()
         element=html::div
         node_ref=node_ref
+        as_child=as_child
       >
-        {children.with_value(|children| children.map(|children| children()))}
+        {children.with_value(|children| children.as_ref().map(|children| children()))}
       </Primitive>
     </Show>
   }

--- a/crates/primitives/src/components/scroll_area.rs
+++ b/crates/primitives/src/components/scroll_area.rs
@@ -73,9 +73,11 @@ pub fn ScrollAreaRoot(
   #[prop(optional, into)] direction: MaybeSignal<Direction>,
   #[prop(default=600.into(), into)] scroll_hide_delay: MaybeSignal<u64>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let viewport = NodeRef::<AnyElement>::new();
   let content = NodeRef::<Div>::new();
@@ -139,8 +141,9 @@ pub fn ScrollAreaRoot(
   view! {
     <Primitive
       element=html::div
-      attrs=merged_attrs
       node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -151,9 +154,11 @@ pub fn ScrollAreaRoot(
 pub fn ScrollAreaViewport(
   #[prop(optional, into)] nonce: MaybeProp<String>,
 
-  #[prop(attrs)] attrs: Attributes,
   //#[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaViewport must be used in a ScrollAreaRoot component");
@@ -219,8 +224,9 @@ pub fn ScrollAreaViewport(
 
       <Primitive
         element=html::div
-        attrs=merged_attrs
         node_ref=context.viewport
+        attrs=merged_attrs
+        as_child=as_child
       >
         <div
           node_ref=content_ref
@@ -238,9 +244,11 @@ pub fn ScrollAreaScrollbar(
   #[prop(optional, into)] force_mount: MaybeSignal<bool>,
   #[prop(optional, into)] orientation: MaybeSignal<Orientation>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbar must be used in a ScrollAreaRoot component");
@@ -271,10 +279,11 @@ pub fn ScrollAreaScrollbar(
     ScrollAreaKind::Hover => {
       view! {
         <ScrollAreaScrollbarHover
-            force_mount=force_mount
+          force_mount=force_mount
           orientation=orientation
-          attrs=attrs
           node_ref=node_ref
+          attrs=attrs
+          as_child=as_child
         >
           {children()}
         </ScrollAreaScrollbarHover>
@@ -283,10 +292,11 @@ pub fn ScrollAreaScrollbar(
     ScrollAreaKind::Scroll => {
       view! {
         <ScrollAreaScrollbarScroll
-            force_mount=force_mount
+          force_mount=force_mount
           orientation=orientation
-          attrs=attrs
           node_ref=node_ref
+          attrs=attrs
+          as_child=as_child
         >
           {children()}
         </ScrollAreaScrollbarScroll>
@@ -295,10 +305,11 @@ pub fn ScrollAreaScrollbar(
     ScrollAreaKind::Auto => {
       view! {
         <ScrollAreaScrollbarAuto
-            force_mount=force_mount
+          force_mount=force_mount
           orientation=orientation
-          attrs=attrs
           node_ref=node_ref
+          attrs=attrs
+          as_child=as_child
         >
           {children()}
         </ScrollAreaScrollbarAuto>
@@ -308,8 +319,9 @@ pub fn ScrollAreaScrollbar(
       view! {
         <ScrollAreaScrollbarVisible
           orientation=orientation
-          attrs=attrs
           node_ref=node_ref
+          attrs=attrs
+          as_child=as_child
         >
           {children()}
         </ScrollAreaScrollbarVisible>
@@ -323,9 +335,11 @@ fn ScrollAreaScrollbarHover(
   force_mount: MaybeSignal<bool>,
   orientation: MaybeSignal<Orientation>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarHover must be used in a ScrollAreaRoot component");
@@ -382,14 +396,15 @@ fn ScrollAreaScrollbarHover(
 
   view! {
     <Show when=move || presence.get()>
-        <ScrollAreaScrollbarAuto
-            force_mount=force_mount
-            orientation=orientation
-            attrs=merged_attrs.clone()
-            node_ref=node_ref
-        >
-            {children.with_value(|children| children())}
-        </ScrollAreaScrollbarAuto>
+      <ScrollAreaScrollbarAuto
+        force_mount=force_mount
+        orientation=orientation
+        node_ref=node_ref
+        attrs=merged_attrs.clone()
+        as_child=as_child.clone()
+      >
+        {children.with_value(|children| children())}
+      </ScrollAreaScrollbarAuto>
     </Show>
   }
 }
@@ -399,9 +414,11 @@ fn ScrollAreaScrollbarScroll(
   force_mount: MaybeSignal<bool>,
   orientation: MaybeSignal<Orientation>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarAuto must be used in a ScrollAreaRoot component");
@@ -488,15 +505,16 @@ fn ScrollAreaScrollbarScroll(
 
   view! {
     <Show when=move || presence.get()>
-        <ScrollAreaScrollbarVisible
-            orientation=orientation
-            node_ref=node_ref
-            attrs=merged_attrs.clone()
-            on_pointer_enter=Callback::new(move |_| send.call(ScrollAreaScrollbarScrollEvent::PointerEnter))
-            on_pointer_leave=Callback::new(move |_| send.call(ScrollAreaScrollbarScrollEvent::PointerLeave))
-        >
-            {children.with_value(|children| children())}
-        </ScrollAreaScrollbarVisible>
+      <ScrollAreaScrollbarVisible
+        orientation=orientation
+        on_pointer_enter=Callback::new(move |_| send.call(ScrollAreaScrollbarScrollEvent::PointerEnter))
+        on_pointer_leave=Callback::new(move |_| send.call(ScrollAreaScrollbarScrollEvent::PointerLeave))
+        node_ref=node_ref
+        attrs=merged_attrs.clone()
+        as_child=as_child
+      >
+        {children.with_value(|children| children())}
+      </ScrollAreaScrollbarVisible>
     </Show>
   }
 }
@@ -506,9 +524,11 @@ fn ScrollAreaScrollbarAuto(
   force_mount: MaybeSignal<bool>,
   orientation: MaybeSignal<Orientation>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeSignal<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarAuto must be used in a ScrollAreaRoot component");
@@ -556,13 +576,14 @@ fn ScrollAreaScrollbarAuto(
 
   view! {
     <Show when=move || presence.get()>
-        <ScrollAreaScrollbarVisible
-            orientation=orientation
-            attrs=merged_attrs.clone()
-            node_ref=node_ref
-        >
-            {children.with_value(|children| children())}
-        </ScrollAreaScrollbarVisible>
+      <ScrollAreaScrollbarVisible
+        orientation=orientation
+        node_ref=node_ref
+        attrs=merged_attrs.clone()
+        as_child=as_child.clone()
+      >
+        {children.with_value(|children| children())}
+      </ScrollAreaScrollbarVisible>
     </Show>
   }
 }
@@ -570,12 +591,15 @@ fn ScrollAreaScrollbarAuto(
 #[component]
 fn ScrollAreaScrollbarVisible(
   orientation: MaybeSignal<Orientation>,
+
   #[prop(default=(|_|{}).into(), into)] on_pointer_enter: Callback<()>,
   #[prop(default=(|_|{}).into(), into)] on_pointer_leave: Callback<()>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarVisible must be used in a ScrollAreaRoot component");
@@ -603,8 +627,6 @@ fn ScrollAreaScrollbarVisible(
       match orientation.get() {
         Orientation::Horizontal => view! {
           <ScrollAreaScrollbarX
-            attrs=merged_attrs
-            node_ref=node_ref
             on_sizes_change=Callback::new(move |sizes| {
               set_sizes.set(sizes);
             })
@@ -641,14 +663,15 @@ fn ScrollAreaScrollbarVisible(
                 viewport.set_scroll_top(get_scroll_position(pointer_position, context.direction.get()) as i32);
               }
             })
+            node_ref=node_ref
+            attrs=merged_attrs
+            as_child=as_child
           >
             {children()}
           </ScrollAreaScrollbarX>
         },
         Orientation::Vertical => view! {
           <ScrollAreaScrollbarY
-            attrs=merged_attrs
-            node_ref=node_ref
             on_sizes_change=Callback::new(move |sizes| {
               set_sizes.set(sizes);
             })
@@ -685,6 +708,9 @@ fn ScrollAreaScrollbarVisible(
                 viewport.set_scroll_top(get_scroll_position(pointer_position, context.direction.get()) as i32);
               }
             })
+            node_ref=node_ref
+            attrs=merged_attrs
+            as_child=as_child
           >
             {children()}
           </ScrollAreaScrollbarY>
@@ -696,11 +722,9 @@ fn ScrollAreaScrollbarVisible(
 
 #[component]
 fn ScrollAreaScrollbarX(
-  #[prop(default=Callback::new(|_:()|{}))] on_pointer_enter: Callback<()>,
-  #[prop(default=Callback::new(|_:()|{}))] on_pointer_leave: Callback<()>,
-
   sizes: MaybeSignal<Sizes>,
   has_thumb: MaybeSignal<bool>,
+
   on_sizes_change: Callback<Sizes>,
   on_thumb_change: Callback<HtmlElement<AnyElement>>,
   on_thumb_pointer_up: Callback<()>,
@@ -708,10 +732,14 @@ fn ScrollAreaScrollbarX(
   on_thumb_position_change: Callback<()>,
   on_wheel_scroll: Callback<f64>,
   on_drag_scroll: Callback<f64>,
+  #[prop(default=Callback::new(|_:()|{}))] on_pointer_enter: Callback<()>,
+  #[prop(default=Callback::new(|_:()|{}))] on_pointer_leave: Callback<()>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarX must be used in a ScrollAreaRoot component");
@@ -758,11 +786,9 @@ fn ScrollAreaScrollbarX(
   view! {
     <ScrollAreaScrollbarImpl
       sizes=Signal::derive(move || sizes.get())
-
+      has_thumb=Signal::derive(move || has_thumb.get())
       on_pointer_enter=on_pointer_enter
       on_pointer_leave=on_pointer_leave
-
-      has_thumb=Signal::derive(move || has_thumb.get())
       on_thumb_pointer_up=on_thumb_pointer_up
       on_thumb_change=on_thumb_change
       on_thumb_pointer_down=Callback::new(move |Pointer{x, ..}| {
@@ -807,9 +833,9 @@ fn ScrollAreaScrollbarX(
           }
         });
       })
-
-      attrs=merged_attrs
       node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </ScrollAreaScrollbarImpl>
@@ -834,6 +860,8 @@ fn ScrollAreaScrollbarY(
   #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarY must be used in a ScrollAreaRoot component");
@@ -873,11 +901,9 @@ fn ScrollAreaScrollbarY(
   view! {
     <ScrollAreaScrollbarImpl
       sizes=Signal::derive(move || sizes.get())
-
+      has_thumb=Signal::derive(move || has_thumb.get())
       on_pointer_enter=on_pointer_enter
       on_pointer_leave=on_pointer_leave
-
-      has_thumb=Signal::derive(move || has_thumb.get())
       on_thumb_pointer_up=on_thumb_pointer_up
       on_thumb_change=on_thumb_change
       on_thumb_pointer_down=Callback::new(move |Pointer{x, ..}| {
@@ -922,9 +948,9 @@ fn ScrollAreaScrollbarY(
           }
         });
       })
-
-      attrs=merged_attrs
       node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </ScrollAreaScrollbarImpl>
@@ -953,11 +979,10 @@ struct Pointer {
 #[component]
 fn ScrollAreaScrollbarImpl(
   sizes: Signal<Sizes>,
+  has_thumb: Signal<bool>,
 
   #[prop(default=(|_|{}).into(), into)] on_pointer_enter: Callback<()>,
   #[prop(default=(|_|{}).into(), into)] on_pointer_leave: Callback<()>,
-
-  has_thumb: Signal<bool>,
   on_thumb_change: Callback<HtmlElement<AnyElement>>,
   on_thumb_pointer_up: Callback<()>,
   on_thumb_pointer_down: Callback<Pointer>,
@@ -966,9 +991,11 @@ fn ScrollAreaScrollbarImpl(
   on_wheel_scroll: Callback<(WheelEvent, f64)>,
   on_resize: Callback<()>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaScrollbarImpl must be used in a ScrollArea component");
@@ -1125,9 +1152,10 @@ fn ScrollAreaScrollbarImpl(
 
   view! {
     <Primitive
-      attrs=attrs
       element=html::div
       node_ref=node_ref
+      attrs=attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -1138,8 +1166,12 @@ fn ScrollAreaScrollbarImpl(
 pub fn ScrollAreaThumb(
   #[prop(optional)] force_mount: MaybeSignal<bool>,
   #[prop(optional)] as_child: Option<bool>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
+  #[prop(optional)] children: Option<ChildrenFn>
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let ScrollbarContextValue { has_thumb, .. } = use_context::<ScrollbarContextValue>()
     .expect("ScrollAreaThumb must be used in a ScrollAreaScrollbarImpl component");
@@ -1148,22 +1180,28 @@ pub fn ScrollAreaThumb(
 
   let presence = create_presence(is_present, node_ref);
 
+  let children = StoredValue::new(children);
+
   view! {
     <Show when=move || presence.get()>
-        <ScrollAreaThumbImpl
-            as_child=as_child
-            attrs=attrs.clone()
-            node_ref=node_ref
-        />
+      <ScrollAreaThumbImpl
+        node_ref=node_ref
+        attrs=attrs.clone()
+        as_child=as_child.clone()
+      >
+        {children.with_value(|children| children.map(|children| children()))}
+      </ScrollAreaThumbImpl>
     </Show>
   }
 }
 
 #[component]
 fn ScrollAreaThumbImpl(
-  as_child: Option<bool>,
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
+  #[prop(optional)] children: Option<ChildrenFn>
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaThumb must be used in a ScrollArea component");
@@ -1248,15 +1286,18 @@ fn ScrollAreaThumbImpl(
       node_ref=node_ref
       attrs=attrs
     >
-      {().into_view()}
+      {children.map(|children| children())}
     </Primitive>
   }
 }
 
 #[component]
 pub fn ScrollAreaCorner(
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
+  #[prop(optional)] children: Option<ChildrenFn>,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ScrollAreaContextValue>()
     .expect("ScrollAreaCorner must be used in a ScrollArea component");
@@ -1311,6 +1352,7 @@ pub fn ScrollAreaCorner(
   });
 
   let attrs = StoredValue::new(attrs);
+  let children = StoredValue::new(children);
 
   view! {
     <Show when=move || has_corner() || has_size()>
@@ -1319,7 +1361,7 @@ pub fn ScrollAreaCorner(
         element=html::div
         node_ref=node_ref
       >
-        {().into_view()}
+        {children.with_value(|children| children.map(|children| children()))}
       </Primitive>
     </Show>
   }

--- a/crates/primitives/src/components/scroll_area.rs
+++ b/crates/primitives/src/components/scroll_area.rs
@@ -1165,11 +1165,10 @@ fn ScrollAreaScrollbarImpl(
 #[component]
 pub fn ScrollAreaThumb(
   #[prop(optional)] force_mount: MaybeSignal<bool>,
-  #[prop(optional)] as_child: Option<bool>,
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional)] children: Option<ChildrenFn>
+  #[prop(optional)] children: Option<ChildrenFn>,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -1199,7 +1198,7 @@ pub fn ScrollAreaThumb(
 fn ScrollAreaThumbImpl(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional)] children: Option<ChildrenFn>
+  #[prop(optional)] children: Option<ChildrenFn>,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {

--- a/crates/primitives/src/components/separator.rs
+++ b/crates/primitives/src/components/separator.rs
@@ -9,7 +9,7 @@ pub fn SeparatorRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional)] children: Option<Children>,
+  #[prop(optional)] children: Option<ChildrenFn>,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -31,13 +31,15 @@ pub fn SeparatorRoot(
     Signal::derive(move || orientation.get().to_string()).into_attribute(),
   )]);
 
+  let children = StoredValue::new(children);
+
   view! {
     <Primitive
       element=html::div
       attrs=merged_attrs
       node_ref=node_ref
     >
-      {children.map(|children| children())}
+      {children.with_value(|children| children.as_ref().map(|children| children()))}
     </Primitive>
   }
 }

--- a/crates/primitives/src/components/separator.rs
+++ b/crates/primitives/src/components/separator.rs
@@ -6,8 +6,12 @@ use crate::{components::primitive::Primitive, util::Orientation, Attributes};
 pub fn SeparatorRoot(
   #[prop(optional, into)] orientation: MaybeSignal<Orientation>,
   #[prop(optional, into)] decorative: MaybeSignal<bool>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
+  #[prop(optional)] children: Option<Children>,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let mut merged_attrs = if decorative.get_untracked() {
     vec![("role", "none".into_attribute())]
@@ -33,7 +37,7 @@ pub fn SeparatorRoot(
       attrs=merged_attrs
       node_ref=node_ref
     >
-      {().into_view()}
+      {children.map(|children| children())}
     </Primitive>
   }
 }

--- a/crates/primitives/src/components/slider.rs
+++ b/crates/primitives/src/components/slider.rs
@@ -304,7 +304,6 @@ fn Slider(
 
   move || {
     let attrs = attrs.clone();
-    let as_child = as_child.clone();
 
     match orientation.get() {
       Orientation::Horizontal => view! {
@@ -678,7 +677,7 @@ fn SliderImpl(
 pub fn SliderTrack(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -716,7 +715,7 @@ pub fn SliderTrack(
 pub fn SliderRange(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -797,7 +796,7 @@ pub fn SliderThumb(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {

--- a/crates/primitives/src/components/slider.rs
+++ b/crates/primitives/src/components/slider.rs
@@ -52,12 +52,15 @@ pub fn SliderRoot(
   #[prop(optional, into)] value: MaybeProp<Vec<f64>>,
   #[prop(optional, into)] default_value: MaybeProp<Vec<f64>>,
   #[prop(optional, into)] inverted: MaybeSignal<bool>,
+
   #[prop(default=(|_|{}).into(), into)] on_value_change: Callback<Vec<f64>>,
   #[prop(default=(|_|{}).into(), into)] on_value_commit: Callback<Vec<f64>>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let thumbs = StoredValue::new(Vec::<HtmlElement<AnyElement>>::new());
   let value_index_to_change = StoredValue::new(Some(0usize));
@@ -179,8 +182,6 @@ pub fn SliderRoot(
 
   view! {
     <Slider
-      node_ref=node_ref
-      attrs=merged_attrs
       min=Signal::derive(move || min.get())
       max=Signal::derive(move || max.get())
       inverted=Signal::derive(move || inverted.get())
@@ -217,6 +218,9 @@ pub fn SliderRoot(
 
         update_values(value + step_in_direction, at_index, true);
       })
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Slider>
@@ -278,6 +282,7 @@ fn Slider(
   inverted: Signal<bool>,
   orientation: Signal<Orientation>,
   direction: Signal<Direction>,
+
   on_slide_start: Callback<f64>,
   on_slide_move: Callback<f64>,
   on_slide_end: Callback<()>,
@@ -288,6 +293,8 @@ fn Slider(
   #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let dom_rect = StoredValue::<Option<DomRect>>::new(None);
 
@@ -297,6 +304,7 @@ fn Slider(
 
   move || {
     let attrs = attrs.clone();
+    let as_child = as_child.clone();
 
     match orientation.get() {
       Orientation::Horizontal => view! {
@@ -319,8 +327,9 @@ fn Slider(
                   on_home_key_down=on_home_key_down
                   on_end_key_down=on_end_key_down
                   on_step_key_down=on_step_key_down
-                  attrs=attrs
                   node_ref=node_ref
+                  attrs=attrs
+                  as_child=as_child
               >
                   {children.with_value(|children| children())}
               </SliderImpl>
@@ -346,8 +355,9 @@ fn Slider(
                   on_home_key_down=on_home_key_down
                   on_end_key_down=on_end_key_down
                   on_step_key_down=on_step_key_down
-                  attrs=attrs
                   node_ref=node_ref
+                  attrs=attrs
+                  as_child=as_child
               >
                   {children.with_value(|children| children())}
               </SliderImpl>
@@ -521,6 +531,7 @@ fn SliderImpl(
   inverted: Signal<bool>,
   orientation: Signal<Orientation>,
   direction: Signal<Direction>,
+
   on_slide_start: Callback<f64>,
   on_slide_move: Callback<f64>,
   on_slide_end: Callback<()>,
@@ -528,9 +539,11 @@ fn SliderImpl(
   on_end_key_down: Callback<KeyboardEvent>,
   on_step_key_down: Callback<Step>,
 
+  #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional_no_strip)] node_ref: NodeRef<AnyElement>,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let SliderImplContextValue { dom_rect } =
     use_context().expect("SliderImpl must be used in a Slider component");
@@ -573,8 +586,6 @@ fn SliderImpl(
   view! {
     <Primitive
       element=html::span
-      node_ref=node_ref
-      attrs=merged_attrs
       on:keydown=move |ev: KeyboardEvent| {
         if ev.key() == "Home" {
             on_home_key_down.call(ev.clone());
@@ -654,6 +665,9 @@ fn SliderImpl(
           on_slide_end.call(());
         }
       }
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -662,9 +676,11 @@ fn SliderImpl(
 
 #[component]
 pub fn SliderTrack(
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let SliderContextValue {
     disabled,
@@ -687,8 +703,9 @@ pub fn SliderTrack(
   view! {
     <Primitive
       element=html::span
-      attrs=merged_attrs
       node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -697,9 +714,11 @@ pub fn SliderTrack(
 
 #[component]
 pub fn SliderRange(
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<SliderContextValue>()
     .expect("SliderRange must be used in a SliderRoot component");
@@ -763,8 +782,9 @@ pub fn SliderRange(
   view! {
     <Primitive
       element=html::span
-      attrs=merged_attrs
       node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -774,9 +794,12 @@ pub fn SliderRange(
 #[component]
 pub fn SliderThumb(
   #[prop(optional, into)] name: MaybeProp<String>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   use_collection_item_ref::<html::AnyElement, SliderCollectionItem>(node_ref, SliderCollectionItem);
   let get_items = use_collection_context::<SliderCollectionItem, AnyElement>();
@@ -944,8 +967,9 @@ pub fn SliderThumb(
     <span style:transform="var(--primitive-slider-thumb-transform)" style:position="absolute" node_ref=span_ref>
       <Primitive
         element=html::span
-        attrs=merged_attrs
         node_ref=node_ref
+        attrs=merged_attrs
+        as_child=as_child
       >
         {children()}
       </Primitive>

--- a/crates/primitives/src/components/switch.rs
+++ b/crates/primitives/src/components/switch.rs
@@ -32,12 +32,15 @@ pub fn SwitchRoot(
   #[prop(optional, into)] name: MaybeProp<String>,
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
   #[prop(optional, into)] required: MaybeSignal<bool>,
+
   #[prop(default=(|_|{}).into(), into)] on_checked_change: Callback<bool>,
   #[prop(default=(|_|{}).into(), into)] on_click: Callback<MouseEvent>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let node_ref = NodeRef::<AnyElement>::new();
   let (is_form_control, set_is_form_control) = create_signal(true);
@@ -90,10 +93,8 @@ pub fn SwitchRoot(
   view! {
     <Primitive
       element=html::button
-      attrs=merged_attrs
-      node_ref=node_ref
       on:click=move |ev: MouseEvent| {
-          on_click.call(ev.clone());
+        on_click.call(ev.clone());
 
         set_checked.update(|checked| *checked = Some(!checked.unwrap_or(false)));
 
@@ -105,28 +106,34 @@ pub fn SwitchRoot(
           }
         }
       }
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
-
-      <Show when=move || is_form_control.get()>
-        <BubbleInput
-            checked=Signal::derive(move || checked.get().unwrap_or(false))
-            bubbles=Signal::derive(move || !has_consumer_stopped_propagation.get_value())
-            name=name.clone()
-            value=value.clone()
-            disabled=Signal::derive(move || disabled.get())
-            required=Signal::derive(move || required.get())
-            control=node_ref
-        />
-      </Show>
     </Primitive>
+
+    <Show when=move || is_form_control.get()>
+      <BubbleInput
+        checked=Signal::derive(move || checked.get().unwrap_or(false))
+        bubbles=Signal::derive(move || !has_consumer_stopped_propagation.get_value())
+        name=name.clone()
+        value=value.clone()
+        disabled=Signal::derive(move || disabled.get())
+        required=Signal::derive(move || required.get())
+        control=node_ref
+      />
+    </Show>
   }
 }
 
 #[component]
 pub fn SwitchThumb(
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
+  #[prop(optional)] children: Option<Children>,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let SwitchContextValue { checked, disabled } =
     use_context().expect("SwitchThumb must be used in a SwitchRoot component");
@@ -155,8 +162,9 @@ pub fn SwitchThumb(
       element=html::span
       node_ref=node_ref
       attrs=merged_attrs
+      as_child=as_child
     >
-      {().into_view()}
+      {children.map(|children| children())}
     </Primitive>
   }
 }

--- a/crates/primitives/src/components/switch.rs
+++ b/crates/primitives/src/components/switch.rs
@@ -38,7 +38,7 @@ pub fn SwitchRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -131,7 +131,7 @@ pub fn SwitchRoot(
 pub fn SwitchThumb(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional)] children: Option<Children>,
+  #[prop(optional)] children: Option<ChildrenFn>,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -157,6 +157,8 @@ pub fn SwitchThumb(
     ),
   ]);
 
+  let children = StoredValue::new(children);
+
   view! {
     <Primitive
       element=html::span
@@ -164,7 +166,7 @@ pub fn SwitchThumb(
       attrs=merged_attrs
       as_child=as_child
     >
-      {children.map(|children| children())}
+      {children.with_value(|children| children.as_ref().map(|children| children()))}
     </Primitive>
   }
 }

--- a/crates/primitives/src/components/tabs.rs
+++ b/crates/primitives/src/components/tabs.rs
@@ -44,7 +44,7 @@ pub fn TabsRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -83,7 +83,7 @@ pub fn TabsList(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -102,6 +102,8 @@ pub fn TabsList(
     ),
   ]);
 
+  let children = StoredValue::new(children);
+
   view! {
     <RovingFocusGroup
       as_child=true
@@ -112,10 +114,10 @@ pub fn TabsList(
       <Primitive
         element=html::div
         node_ref=node_ref
-        attrs=merged_attrs
+        attrs=merged_attrs.clone()
         as_child=as_child
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Primitive>
     </RovingFocusGroup>
   }
@@ -132,7 +134,7 @@ pub fn TabsTrigger(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -190,8 +192,9 @@ pub fn TabsTrigger(
     ),
   ]);
 
-  let keydown_value = value.clone();
-  let focus_value = value.clone();
+  let children = StoredValue::new(children);
+  let value = StoredValue::new(value);
+
   view! {
     <RovingFocusGroupItem
       as_child=true
@@ -201,35 +204,35 @@ pub fn TabsTrigger(
       <Primitive
         element=html::button
         on:mousedown=move|ev: MouseEvent| {
-            on_mouse_down.call(ev.clone());
+          on_mouse_down.call(ev.clone());
 
           if !disabled.get() && ev.button() == 0 && !ev.ctrl_key() {
-            on_value_change.call(value.get());
+            on_value_change.call(value.get_value().get());
           } else {
             ev.prevent_default();
           }
         }
         on:keydown=move |ev: KeyboardEvent| {
-            on_key_down.call(ev.clone());
+          on_key_down.call(ev.clone());
 
           if [" ", "Enter"].contains(&ev.key().as_str()) {
-            on_value_change.call(keydown_value.get());
+            on_value_change.call(value.get_value().get());
           }
         }
         on:focus=move |ev: FocusEvent| {
-            on_focus.call(ev.clone());
+          on_focus.call(ev.clone());
 
           let is_automatic_activation = activation_mode.get() != ActivationMode::Manual;
 
           if !is_selected.get() && !disabled.get() && is_automatic_activation {
-            on_value_change.call(focus_value.get());
+            on_value_change.call(value.get_value().get());
           }
         }
         node_ref=node_ref
-        attrs=merged_attrs
+        attrs=merged_attrs.clone()
         as_child=as_child
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Primitive>
     </RovingFocusGroupItem>
   }

--- a/crates/primitives/src/components/tabs.rs
+++ b/crates/primitives/src/components/tabs.rs
@@ -36,14 +36,17 @@ pub enum ActivationMode {
 pub fn TabsRoot(
   #[prop(optional, into)] value: MaybeProp<String>,
   #[prop(optional, into)] default_value: MaybeProp<String>,
-  #[prop(default=(|_|{}).into(), into)] on_value_change: Callback<String>,
   #[prop(optional, into)] orientation: MaybeSignal<Orientation>,
   #[prop(optional, into)] direction: MaybeSignal<Direction>,
   #[prop(optional, into)] activation_mode: MaybeSignal<ActivationMode>,
 
-  #[prop(attrs)] attrs: Attributes,
+  #[prop(default=(|_|{}).into(), into)] on_value_change: Callback<String>,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (value, set_value) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || value.get()),
@@ -65,8 +68,9 @@ pub fn TabsRoot(
   view! {
     <Primitive
       element=html::div
-      attrs=attrs
       node_ref=node_ref
+      attrs=attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>
@@ -77,9 +81,11 @@ pub fn TabsRoot(
 pub fn TabsList(
   #[prop(default=true.into(), into)] should_loop: MaybeSignal<bool>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let TabsContextValue {
     orientation,
@@ -105,8 +111,9 @@ pub fn TabsList(
     >
       <Primitive
         element=html::div
-        attrs=merged_attrs
         node_ref=node_ref
+        attrs=merged_attrs
+        as_child=as_child
       >
         {children()}
       </Primitive>
@@ -118,13 +125,16 @@ pub fn TabsList(
 pub fn TabsTrigger(
   #[prop(optional, into)] value: MaybeSignal<String>,
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
+
   #[prop(default=(|_|{}).into(), into)] on_mouse_down: Callback<MouseEvent>,
   #[prop(default=(|_|{}).into(), into)] on_key_down: Callback<KeyboardEvent>,
   #[prop(default=(|_|{}).into(), into)] on_focus: Callback<FocusEvent>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let TabsContextValue {
     base_id,
@@ -190,8 +200,6 @@ pub fn TabsTrigger(
     >
       <Primitive
         element=html::button
-        attrs=merged_attrs
-        node_ref=node_ref
         on:mousedown=move|ev: MouseEvent| {
             on_mouse_down.call(ev.clone());
 
@@ -217,6 +225,9 @@ pub fn TabsTrigger(
             on_value_change.call(focus_value.get());
           }
         }
+        node_ref=node_ref
+        attrs=merged_attrs
+        as_child=as_child
       >
         {children()}
       </Primitive>
@@ -229,9 +240,11 @@ pub fn TabsContent(
   #[prop(optional, into)] value: MaybeSignal<String>,
   #[prop(optional, into)] force_mount: MaybeSignal<bool>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let TabsContextValue {
     base_id,
@@ -313,14 +326,15 @@ pub fn TabsContent(
   let children = StoredValue::new(children);
 
   view! {
-      <Show when=move || presence.get()>
-        <Primitive
-            element=html::div
-            attrs=merged_attrs.clone()
-            node_ref=node_ref
-        >
-            {children.with_value(|children| children())}
-        </Primitive>
-      </Show>
+    <Show when=move || presence.get()>
+      <Primitive
+        element=html::div
+        node_ref=node_ref
+        attrs=merged_attrs.clone()
+        as_child=as_child
+      >
+        {children.with_value(|children| children())}
+      </Primitive>
+    </Show>
   }
 }

--- a/crates/primitives/src/components/toggle.rs
+++ b/crates/primitives/src/components/toggle.rs
@@ -12,12 +12,15 @@ pub fn ToggleRoot(
   #[prop(optional, into)] pressed: MaybeProp<bool>,
   #[prop(optional, into)] default_pressed: MaybeProp<bool>,
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
+
   #[prop(default=(|_|{}).into(), into)] on_pressed_changed: Callback<bool>,
   #[prop(default=(|_|{}).into(), into)] on_click: Callback<MouseEvent>,
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (pressed, set_pressed) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || pressed.get()),
@@ -49,9 +52,7 @@ pub fn ToggleRoot(
 
   view! {
     <Primitive
-      attrs=merged_attrs
       element=html::button
-      node_ref=node_ref
       on:click=move |ev: MouseEvent| {
           on_click.call(ev.clone());
 
@@ -59,6 +60,9 @@ pub fn ToggleRoot(
           set_pressed.update(|pressed| *pressed = Some(!pressed.unwrap_or(false)));
         }
       }
+      node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </Primitive>

--- a/crates/primitives/src/components/toggle.rs
+++ b/crates/primitives/src/components/toggle.rs
@@ -18,7 +18,7 @@ pub fn ToggleRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {

--- a/crates/primitives/src/components/toggle_group.rs
+++ b/crates/primitives/src/components/toggle_group.rs
@@ -51,9 +51,11 @@ pub fn ToggleGroupRoot(
   #[prop(optional, into)] orientation: MaybeSignal<Orientation>,
   #[prop(optional, into)] direction: MaybeSignal<Direction>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   match kind {
     ToggleGroupKind::Single {
@@ -70,8 +72,9 @@ pub fn ToggleGroupRoot(
         value=value
         default_value=default_value
         on_value_change=on_value_change.unwrap_or((|_|{}).into())
-        attrs=attrs
         node_ref=node_ref
+        attrs=attrs
+        as_child=as_child
       >
         {children()}
       </ToggleGroupSingleImpl>
@@ -90,8 +93,9 @@ pub fn ToggleGroupRoot(
         value=value
         default_value=default_value
         on_value_change=on_value_change.unwrap_or((|_|{}).into())
-        attrs=attrs
         node_ref=node_ref
+        attrs=attrs
+        as_child=as_child
       >
         {children()}
       </ToggleGroupMultipleImpl>
@@ -120,15 +124,16 @@ fn ToggleGroupSingleImpl(
   should_loop: MaybeSignal<bool>,
   orientation: MaybeSignal<Orientation>,
   direction: MaybeSignal<Direction>,
-
   #[prop(optional, into)] value: MaybeProp<String>,
   #[prop(optional, into)] default_value: MaybeProp<String>,
 
   on_value_change: Callback<String>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (value, set_value) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || value.get()),
@@ -156,6 +161,7 @@ fn ToggleGroupSingleImpl(
       direction=direction
       node_ref=node_ref
       attrs=attrs
+      as_child=as_child
     >
       {children()}
     </ToggleGroup>
@@ -169,15 +175,16 @@ fn ToggleGroupMultipleImpl(
   should_loop: MaybeSignal<bool>,
   orientation: MaybeSignal<Orientation>,
   direction: MaybeSignal<Direction>,
-
   #[prop(optional, into)] value: MaybeProp<Vec<String>>,
   #[prop(optional, into)] default_value: MaybeProp<Vec<String>>,
 
   on_value_change: Callback<Vec<String>>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let (value, set_value) = create_controllable_signal(CreateControllableSignalProps {
     value: Signal::derive(move || value.get()),
@@ -222,6 +229,7 @@ fn ToggleGroupMultipleImpl(
       direction=direction
       node_ref=node_ref
       attrs=attrs
+      as_child=as_child
     >
       {children()}
     </ToggleGroup>
@@ -242,9 +250,11 @@ fn ToggleGroup(
   orientation: MaybeSignal<Orientation>,
   direction: MaybeSignal<Direction>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   provide_context(ToggleGroupStateContextValue {
     roving_focus: Signal::derive(move || roving_focus.get()),
@@ -254,6 +264,7 @@ fn ToggleGroup(
   view! {
     {move || {
       let children = children.clone();
+      let as_child = as_child.clone();
       let mut merged_attrs = attrs.clone();
 
       merged_attrs.extend([
@@ -273,8 +284,9 @@ fn ToggleGroup(
           >
             <Primitive
               element=html::div
-              attrs=merged_attrs
               node_ref=node_ref
+              attrs=merged_attrs
+              as_child=as_child
             >
               {children()}
             </Primitive>
@@ -284,8 +296,9 @@ fn ToggleGroup(
         view! {
           <Primitive
             element=html::div
-            attrs=merged_attrs
             node_ref=node_ref
+            attrs=merged_attrs
+            as_child=as_child
           >
             {children()}
           </Primitive>
@@ -300,9 +313,11 @@ pub fn ToggleGroupItem(
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
   #[prop(into)] value: MaybeSignal<String>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let ToggleGroupValueContextValue {
     kind,
@@ -324,6 +339,7 @@ pub fn ToggleGroupItem(
   view! {
     {move || {
       let children = children.clone();
+      let as_child = as_child.clone();
       let mut merged_attrs = attrs.clone();
 
       if kind == ToggleGroupValueKind::Single {
@@ -342,8 +358,6 @@ pub fn ToggleGroupItem(
             <ToggleRoot
               disabled=is_disabled
               pressed=is_pressed
-              attrs=merged_attrs
-              node_ref=node_ref
               on_pressed_changed=Callback::new(move |pressed| {
                 if pressed {
                   on_item_activate.call(on_pressed_value.get());
@@ -351,6 +365,9 @@ pub fn ToggleGroupItem(
                   on_item_deactivate.call(on_pressed_value.get());
                 }
               })
+              node_ref=node_ref
+              attrs=merged_attrs
+              as_child=as_child
             >
               {children()}
             </ToggleRoot>
@@ -361,8 +378,6 @@ pub fn ToggleGroupItem(
           <ToggleRoot
             disabled=is_disabled
             pressed=is_pressed
-            attrs=merged_attrs
-            node_ref=node_ref
             on_pressed_changed=Callback::new(move |pressed| {
               if pressed {
                 on_item_activate.call(on_pressed_value.get());
@@ -370,6 +385,9 @@ pub fn ToggleGroupItem(
                 on_item_deactivate.call(on_pressed_value.get());
               }
             })
+            node_ref=node_ref
+            attrs=merged_attrs
+            as_child=as_child
           >
             {children()}
           </ToggleRoot>

--- a/crates/primitives/src/components/toolbar.rs
+++ b/crates/primitives/src/components/toolbar.rs
@@ -29,7 +29,7 @@ pub fn ToolbarRoot(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -52,6 +52,8 @@ pub fn ToolbarRoot(
 
   merged_attrs.extend(attrs);
 
+  let children = StoredValue::new(children);
+
   view! {
     <RovingFocusGroup
       orientation=Signal::derive(move || orientation.get())
@@ -61,10 +63,10 @@ pub fn ToolbarRoot(
       <Primitive
         element=html::div
         node_ref=node_ref
-        attrs=merged_attrs
+        attrs=merged_attrs.clone()
         as_child=as_child
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Primitive>
     </RovingFocusGroup>
   }
@@ -74,7 +76,7 @@ pub fn ToolbarRoot(
 pub fn ToolbarSeparator(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  #[prop(optional)] children: Option<Children>,
+  #[prop(optional)] children: Option<ChildrenFn>,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
@@ -86,6 +88,8 @@ pub fn ToolbarSeparator(
     Orientation::Vertical => Orientation::Horizontal,
   });
 
+  let children = StoredValue::new(children);
+
   view! {
     <SeparatorRoot
       orientation=orientation
@@ -93,7 +97,7 @@ pub fn ToolbarSeparator(
       attrs=attrs
       as_child=as_child
     >
-      {children.map(|children| children())}
+      {children.with_value(|children| children.as_ref().map(|children| children()))}
     </SeparatorRoot>
   }
 }
@@ -104,12 +108,14 @@ pub fn ToolbarButton(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let mut merged_attrs = vec![("type", "button".into_attribute())];
   merged_attrs.extend(attrs);
+
+  let children = StoredValue::new(children);
 
   view! {
     <RovingFocusGroupItem
@@ -119,10 +125,10 @@ pub fn ToolbarButton(
       <Primitive
         element=html::button
         node_ref=node_ref
-        attrs=merged_attrs
+        attrs=merged_attrs.clone()
         as_child=as_child
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Primitive>
     </RovingFocusGroupItem>
   }
@@ -134,10 +140,12 @@ pub fn ToolbarLink(
 
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
-  children: Children,
+  children: ChildrenFn,
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
+  let children = StoredValue::new(children);
+
   view! {
     <RovingFocusGroupItem
       as_child=true
@@ -146,7 +154,7 @@ pub fn ToolbarLink(
       <Primitive
         element=html::a
         node_ref=node_ref
-        attrs=attrs
+        attrs=attrs.clone()
         as_child=as_child
         on:keydown=move |ev: KeyboardEvent| {
           on_key_down.call(ev.clone());
@@ -160,7 +168,7 @@ pub fn ToolbarLink(
           }
         }
       >
-        {children()}
+        {children.with_value(|children| children())}
       </Primitive>
     </RovingFocusGroupItem>
   }
@@ -222,16 +230,18 @@ pub fn ToolbarToggleItem(
 
   #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
+  let children = StoredValue::new(children);
+
   view! {
     <ToolbarButton as_child=true>
       <ToggleGroupItem
         disabled=Signal::derive(move || disabled.get())
-        value=value
+        value=value.clone()
         node_ref=node_ref
-        attrs=attrs
+        attrs=attrs.clone()
         as_child=as_child
       >
-        {children()}
+        {children.with_value(|children| children())}
       </ToggleGroupItem>
     </ToolbarButton>
   }

--- a/crates/primitives/src/components/toolbar.rs
+++ b/crates/primitives/src/components/toolbar.rs
@@ -26,9 +26,12 @@ pub fn ToolbarRoot(
   #[prop(optional, into)] orientation: MaybeSignal<Orientation>,
   #[prop(optional, into)] direction: MaybeSignal<Direction>,
   #[prop(default=true.into(), into)] should_loop: MaybeSignal<bool>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   provide_context(ToolbarContextValue {
     orientation: Signal::derive(move || orientation.get()),
@@ -57,8 +60,9 @@ pub fn ToolbarRoot(
     >
       <Primitive
         element=html::div
-        attrs=merged_attrs
         node_ref=node_ref
+        attrs=merged_attrs
+        as_child=as_child
       >
         {children()}
       </Primitive>
@@ -70,6 +74,9 @@ pub fn ToolbarRoot(
 pub fn ToolbarSeparator(
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
   #[prop(attrs)] attrs: Attributes,
+  #[prop(optional)] children: Option<Children>,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let ToolbarContextValue { orientation, .. } =
     use_context().expect("ToolbarSeparator must be used in a ToolbarRoot component");
@@ -82,19 +89,24 @@ pub fn ToolbarSeparator(
   view! {
     <SeparatorRoot
       orientation=orientation
-      attrs=attrs
       node_ref=node_ref
-    />
+      attrs=attrs
+      as_child=as_child
+    >
+      {children.map(|children| children())}
+    </SeparatorRoot>
   }
 }
 
 #[component]
 pub fn ToolbarButton(
-  #[prop(optional)] as_child: Option<bool>,
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let mut merged_attrs = vec![("type", "button".into_attribute())];
   merged_attrs.extend(attrs);
@@ -106,9 +118,9 @@ pub fn ToolbarButton(
     >
       <Primitive
         element=html::button
-        as_child=as_child
-        attrs=merged_attrs
         node_ref=node_ref
+        attrs=merged_attrs
+        as_child=as_child
       >
         {children()}
       </Primitive>
@@ -119,9 +131,12 @@ pub fn ToolbarButton(
 #[component]
 pub fn ToolbarLink(
   #[prop(default=(|_|{}).into(), into)] on_key_down: Callback<KeyboardEvent>,
-  #[prop(attrs)] attrs: Attributes,
+
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: Children,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   view! {
     <RovingFocusGroupItem
@@ -130,10 +145,11 @@ pub fn ToolbarLink(
     >
       <Primitive
         element=html::a
-        attrs=attrs
         node_ref=node_ref
+        attrs=attrs
+        as_child=as_child
         on:keydown=move |ev: KeyboardEvent| {
-            on_key_down.call(ev.clone());
+          on_key_down.call(ev.clone());
 
           if ev.key() == " " {
             if let Some(current_target) = ev.current_target() {
@@ -158,9 +174,11 @@ pub fn ToolbarToggleGroup(
   #[prop(optional, into)] orientation: MaybeSignal<Orientation>,
   #[prop(optional, into)] direction: MaybeSignal<Direction>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   let context = use_context::<ToolbarContextValue>()
     .expect("ToolbarToggleGroup must be in a ToolbarRoot component");
@@ -180,12 +198,13 @@ pub fn ToolbarToggleGroup(
   view! {
     <ToggleGroupRoot
       kind=kind
-      attrs=merged_attrs
       disabled=Signal::derive(move || disabled.get())
       orientation=Signal::derive(move || orientation.get())
       direction=Signal::derive(move || direction.get())
       roving_focus=false
       node_ref=node_ref
+      attrs=merged_attrs
+      as_child=as_child
     >
       {children()}
     </ToggleGroupRoot>
@@ -197,19 +216,20 @@ pub fn ToolbarToggleItem(
   #[prop(optional, into)] disabled: MaybeSignal<bool>,
   #[prop(into)] value: MaybeSignal<String>,
 
-  #[prop(attrs)] attrs: Attributes,
   #[prop(optional)] node_ref: NodeRef<AnyElement>,
+  #[prop(attrs)] attrs: Attributes,
   children: ChildrenFn,
+
+  #[prop(optional, into)] as_child: MaybeProp<bool>,
 ) -> impl IntoView {
   view! {
-    <ToolbarButton
-      as_child=true
-    >
+    <ToolbarButton as_child=true>
       <ToggleGroupItem
-        attrs=attrs
         disabled=Signal::derive(move || disabled.get())
         value=value
         node_ref=node_ref
+        attrs=attrs
+        as_child=as_child
       >
         {children()}
       </ToggleGroupItem>

--- a/examples/csr-with-tailwind/src/main.rs
+++ b/examples/csr-with-tailwind/src/main.rs
@@ -514,7 +514,7 @@ fn AccordionDemo() -> impl IntoView {
 #[component]
 fn AccordionItemDemo(
   #[prop(into)] value: MaybeSignal<String>,
-  children: Children,
+  children: ChildrenFn,
 ) -> impl IntoView {
   view! {
       <AccordionItem
@@ -527,11 +527,13 @@ fn AccordionItemDemo(
 }
 
 #[component]
-fn AccordionTriggerDemo(children: Children) -> impl IntoView {
+fn AccordionTriggerDemo(children: ChildrenFn) -> impl IntoView {
+  let children = StoredValue::new(children);
+
   view! {
       <AccordionHeader attr:class="flex">
           <AccordionTrigger attr:class="text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-white px-5 text-[15px] leading-none shadow-[0_1px_0] outline-none">
-              {children()}
+              {children.with_value(|children| children())}
               <ChevronDownIcon
                   attr:class="text-violet10 ease-[cubic-bezier(0.87,_0,_0.13,_1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
                   attr:aria-hidden=true.into_attribute()
@@ -1117,17 +1119,19 @@ fn SliderDemo() -> impl IntoView {
 
 #[component]
 fn ScrollAreaDemo() -> impl IntoView {
-  let tags = (1..=50)
-    .rev()
-    .map(|num| format!("v1.2.0-beta.{num}"))
-    .collect::<Vec<_>>();
+  let tags = StoredValue::new(
+    (1..=50)
+      .rev()
+      .map(|num| format!("v1.2.0-beta.{num}"))
+      .collect::<Vec<_>>(),
+  );
 
   view! {
       <ScrollAreaRoot attr:class="w-[200px] h-[225px] rounded overflow-hidden shadow-[0_2px_10px] shadow-blackA4 bg-white">
           <ScrollAreaViewport attr:class="w-full h-full rounded">
               <div class="py-[15px] px-5">
                   <div class="text-violet11 text-[15px] leading-[18px] font-medium">"Tags"</div>
-                  <For each=move || tags.clone() key=|n| n.clone() let:data>
+                  <For each=move || tags.get_value() key=|n| n.clone() let:data>
                       <div class="text-mauve12 text-[13px] leading-[18px] mt-2.5 pt-2.5 border-t border-t-mauve6">
                           {data}
                       </div>

--- a/examples/ssr-with-actix-tailwind/src/primitives.rs
+++ b/examples/ssr-with-actix-tailwind/src/primitives.rs
@@ -548,7 +548,7 @@ fn AccordionDemo() -> impl IntoView {
 }
 
 #[component]
-fn AccordionItemDemo(#[prop(into)] value: MaybeSignal<String>, children: Children) -> impl IntoView {
+fn AccordionItemDemo(#[prop(into)] value: MaybeSignal<String>, children: ChildrenFn) -> impl IntoView {
   view! {
       <AccordionItem
           value=value
@@ -560,11 +560,13 @@ fn AccordionItemDemo(#[prop(into)] value: MaybeSignal<String>, children: Childre
 }
 
 #[component]
-fn AccordionTriggerDemo(children: Children) -> impl IntoView {
+fn AccordionTriggerDemo(children: ChildrenFn) -> impl IntoView {
+    let children = StoredValue::new(children);
+
   view! {
       <AccordionHeader attr:class="flex">
           <AccordionTrigger attr:class="text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-white px-5 text-[15px] leading-none shadow-[0_1px_0] outline-none">
-              {children()}
+              {children.with_value(|children| children())}
               <ChevronDownIcon
                   attr:class="text-violet10 ease-[cubic-bezier(0.87,_0,_0.13,_1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
                   attr:aria-hidden=true.into_attribute()
@@ -1150,17 +1152,17 @@ fn SliderDemo() -> impl IntoView {
 
 #[component]
 fn ScrollAreaDemo() -> impl IntoView {
-  let tags = (1..=50)
+  let tags = StoredValue::new((1..=50)
     .rev()
     .map(|num| format!("v1.2.0-beta.{num}"))
-    .collect::<Vec<_>>();
+    .collect::<Vec<_>>());
 
   view! {
       <ScrollAreaRoot attr:class="w-[200px] h-[225px] rounded overflow-hidden shadow-[0_2px_10px] shadow-blackA4 bg-white">
           <ScrollAreaViewport attr:class="w-full h-full rounded">
               <div class="py-[15px] px-5">
                   <div class="text-violet11 text-[15px] leading-[18px] font-medium">"Tags"</div>
-                  <For each=move || tags.clone() key=|n| n.clone() let:data>
+                  <For each=move || tags.get_value() key=|n| n.clone() let:data>
                       <div class="text-mauve12 text-[13px] leading-[18px] mt-2.5 pt-2.5 border-t border-t-mauve6">
                           {data}
                       </div>

--- a/examples/ssr-with-axum-tailwind/src/primitives.rs
+++ b/examples/ssr-with-axum-tailwind/src/primitives.rs
@@ -547,7 +547,7 @@ fn AccordionDemo() -> impl IntoView {
 }
 
 #[component]
-fn AccordionItemDemo(#[prop(into)] value: MaybeSignal<String>, children: Children) -> impl IntoView {
+fn AccordionItemDemo(#[prop(into)] value: MaybeSignal<String>, children: ChildrenFn) -> impl IntoView {
   view! {
       <AccordionItem
           value=value
@@ -559,11 +559,13 @@ fn AccordionItemDemo(#[prop(into)] value: MaybeSignal<String>, children: Childre
 }
 
 #[component]
-fn AccordionTriggerDemo(children: Children) -> impl IntoView {
+fn AccordionTriggerDemo(children: ChildrenFn) -> impl IntoView {
+    let children = StoredValue::new(children);
+
   view! {
       <AccordionHeader attr:class="flex">
           <AccordionTrigger attr:class="text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-white px-5 text-[15px] leading-none shadow-[0_1px_0] outline-none">
-              {children()}
+              {children.with_value(|children| children())}
               <ChevronDownIcon
                   attr:class="text-violet10 ease-[cubic-bezier(0.87,_0,_0.13,_1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
                   attr:aria-hidden=true.into_attribute()
@@ -1149,17 +1151,17 @@ fn SliderDemo() -> impl IntoView {
 
 #[component]
 fn ScrollAreaDemo() -> impl IntoView {
-  let tags = (1..=50)
+  let tags = StoredValue::new((1..=50)
     .rev()
     .map(|num| format!("v1.2.0-beta.{num}"))
-    .collect::<Vec<_>>();
+    .collect::<Vec<_>>());
 
   view! {
       <ScrollAreaRoot attr:class="w-[200px] h-[225px] rounded overflow-hidden shadow-[0_2px_10px] shadow-blackA4 bg-white">
           <ScrollAreaViewport attr:class="w-full h-full rounded">
               <div class="py-[15px] px-5">
                   <div class="text-violet11 text-[15px] leading-[18px] font-medium">"Tags"</div>
-                  <For each=move || tags.clone() key=|n| n.clone() let:data>
+                  <For each=move || tags.get_value() key=|n| n.clone() let:data>
                       <div class="text-mauve12 text-[13px] leading-[18px] mt-2.5 pt-2.5 border-t border-t-mauve6">
                           {data}
                       </div>


### PR DESCRIPTION
the as_child prop in existing components currently don't exist or aren't reactive